### PR TITLE
META-13447: Generator Should Produce Came Case Warnings For Fields That Will Be Disregarded By JSON Ser

### DIFF
--- a/openapi-scala/src/main/scala/com/enfore/apis/ast/ASTTranslationFunctions.scala
+++ b/openapi-scala/src/main/scala/com/enfore/apis/ast/ASTTranslationFunctions.scala
@@ -9,8 +9,11 @@ import com.enfore.apis.repr.TypeRepr._
 import com.enfore.apis.repr._
 
 import scala.collection.immutable
+import scala.util.matching.Regex
 
 object ASTTranslationFunctions {
+
+  val camelCaseExpr: Regex = "(([^_A-Z])([A-Z])+)".r
 
   final case class PackageName(name: String)
 
@@ -271,6 +274,8 @@ object ASTTranslationFunctions {
   ): Option[NewType] = {
     val mapped: immutable.Iterable[Option[Symbol]] = properties map {
       case (name: String, repr: SchemaOrReferenceObject) =>
+        if (camelCaseExpr.findAllIn(name).nonEmpty)
+          println(s"[WARN] You are using camel case name in $name. JSON serialiser will only respect snake cases.")
         val loaded: Option[TypeRepr] = getTypeRepr(required, name, repr, allSchemas)
         assert(loaded.isDefined, s"$name in $typeName could not be parsed.")
         loaded map (makeSymbolFromTypeRepr(name, _))

--- a/openapi-scala/src/test/scala/com/enfore/apis/ast/AstTranslationSpec.scala
+++ b/openapi-scala/src/test/scala/com/enfore/apis/ast/AstTranslationSpec.scala
@@ -616,4 +616,13 @@ class AstTranslationSpec extends AnyFlatSpec with Matchers {
     filtered.get("regularComponent") shouldBe components.get("regularComponent")
   }
 
+  "Helper functions" should "ensure that a warning is produced on camelCase strings" in {
+    val expr = ASTTranslationFunctions.camelCaseExpr
+
+    expr.findAllIn("myCamelCase").toList shouldBe List("yC", "lC")
+    expr.findAllIn("SimpleCase").toList shouldBe List("eC")
+    expr.findAllIn("myMix_case_Expr").toList shouldBe List("yM")
+    expr.findAllIn("my_snake_case").toList shouldBe List()
+  }
+
 }


### PR DESCRIPTION
By default, we apply `renaming.snakeCase` to all generated Circe serialisers. This means that if a user uses camel case in their specification, the server will not respect that.

This can often become a problem for us to find out much later. This PR adds code to print out a warning during the code generation process if a field is camel case.