### PR TITLE
Drop Null Values In Json Outputs To HTTP Requests

### DIFF
--- a/openapi-http4s-lib/src/main/scala/com/enfore/apis/http4s/ErrorHandler.scala
+++ b/openapi-http4s-lib/src/main/scala/com/enfore/apis/http4s/ErrorHandler.scala
@@ -50,28 +50,28 @@ class ErrorHandlerImplementation(convertThrowableToServiceExceptionFn: Throwable
     err match {
       case e: ServiceError =>
         logger.error("ServiceError", err)
-        InternalServerError(e.asJson)
+        InternalServerError(e.asJson.dropNullValues)
       case e: ItemAlreadyExists =>
         logger.info("ItemAlreadyExists", err)
-        Conflict(e.asJson)
+        Conflict(e.asJson.dropNullValues)
       case e: ServiceObjectLocked =>
         logger.info("ObjectLocked", err)
-        Locked(e.asJson)
+        Locked(e.asJson.dropNullValues)
       case e: ItemDoesNotExist =>
         logger.info("ItemDoesNotExist", err)
-        NotFound(e.asJson)
+        NotFound(e.asJson.dropNullValues)
       case e: RequestConflict =>
         logger.warn("RequestConflict", err)
-        Conflict(e.asJson)
+        Conflict(e.asJson.dropNullValues)
       case e: PermissionRequired =>
         logger.info("PermissionRequired", err)
-        Forbidden(e.asJson)
+        Forbidden(e.asJson.dropNullValues)
       case e: WrongRequestContent =>
         logger.info("WrongRequestContent", err)
-        BadRequest(e.asJson)
+        BadRequest(e.asJson.dropNullValues)
       case e: UnprocessableContent =>
         logger.info("UnprocessableContent", err)
-        UnprocessableEntity(e.asJson)
+        UnprocessableEntity(e.asJson.dropNullValues)
     }
 
 }

--- a/openapi-scala/src/main/scala/com/enfore/apis/generator/ScalaGenerator.scala
+++ b/openapi-scala/src/main/scala/com/enfore/apis/generator/ScalaGenerator.scala
@@ -196,7 +196,7 @@ object ScalaGenerator {
       .map(_.typeName)
       .map(
         member =>
-          s"""implicit def case${member} = at[$member](_.asJson.deepMerge(Json.obj("$discriminator" -> Json.fromString("$member"))))"""
+          s"""implicit def case${member} = at[$member](_.asJson.dropNullValues.deepMerge(Json.obj("$discriminator" -> Json.fromString("$member"))))"""
       )
       .mkString(s"\n$margin")
 

--- a/openapi-scala/src/main/scala/com/enfore/apis/generator/http4s/RouteGenerator.scala
+++ b/openapi-scala/src/main/scala/com/enfore/apis/generator/http4s/RouteGenerator.scala
@@ -315,7 +315,7 @@ object RouteGenerator {
     if (response.isEmpty) {
       s"(_: ${firstResponseType(response)}) => EmptyGenerator($status)()"
     } else {
-      s"(x: ${firstResponseType(response)}) => EntityGenerator($status)(x.asJson)"
+      s"(x: ${firstResponseType(response)}) => EntityGenerator($status)(x.asJson.dropNullValues)"
     }
 
   private def getResponseStatus(route: RouteDefinition): String =

--- a/openapi-scala/src/test/scala/com/enfore/apis/generator/ComponentsTypeReprSpec.scala
+++ b/openapi-scala/src/test/scala/com/enfore/apis/generator/ComponentsTypeReprSpec.scala
@@ -425,8 +425,8 @@ class ComponentsTypeReprSpec extends AnyFlatSpec with Matchers {
         | type Union = IndividualCustomer :+: OrganizationCustomer :+: CNil
         |
         | object jsonConversions extends Poly1 {
-        |   implicit def caseIndividualCustomer = at[IndividualCustomer](_.asJson.deepMerge(Json.obj("@type" -> Json.fromString("IndividualCustomer"))))
-        |   implicit def caseOrganizationCustomer = at[OrganizationCustomer](_.asJson.deepMerge(Json.obj("@type" -> Json.fromString("OrganizationCustomer"))))
+        |   implicit def caseIndividualCustomer = at[IndividualCustomer](_.asJson.dropNullValues.deepMerge(Json.obj("@type" -> Json.fromString("IndividualCustomer"))))
+        |   implicit def caseOrganizationCustomer = at[OrganizationCustomer](_.asJson.dropNullValues.deepMerge(Json.obj("@type" -> Json.fromString("OrganizationCustomer"))))
         | }
         |
         | implicit val customEncoders: Encoder[Customer] = new Encoder[Customer] {

--- a/openapi-scala/src/test/scala/com/enfore/apis/generator/http4s/Http4sGeneratorSpec.scala
+++ b/openapi-scala/src/test/scala/com/enfore/apis/generator/http4s/Http4sGeneratorSpec.scala
@@ -89,7 +89,7 @@ class Http4sGeneratorSpec extends AnyFreeSpec with Matchers {
       |
       |    HttpRoutes.of[F] {
       |      case request @ GET -> Root / "contacts" / "individual" =>
-      |        errorHandler.resolve(impl.`dummyFunction`(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson))
+      |        errorHandler.resolve(impl.`dummyFunction`(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))
       |    }
       |  }
       |}

--- a/openapi-scala/src/test/scala/com/enfore/apis/generator/http4s/RouteGeneratorSpec.scala
+++ b/openapi-scala/src/test/scala/com/enfore/apis/generator/http4s/RouteGeneratorSpec.scala
@@ -49,7 +49,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`GET /contacts/individual`,
     List(
       """case request @ GET -> Root / "contacts" / "individual" =>""",
-      """  errorHandler.resolve(impl.dummyFunction(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson))"""
+      """  errorHandler.resolve(impl.dummyFunction(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))"""
     )
   )
 
@@ -57,7 +57,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`GET /org/{org-id}/contacts/individual`,
     List(
       """case request @ GET -> Root / "org" / orgId / "contacts" / "individual" =>""",
-      """  errorHandler.resolve(impl.`GET /org/{org-id}/contacts/individual`(orgId)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson))"""
+      """  errorHandler.resolve(impl.`GET /org/{org-id}/contacts/individual`(orgId)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))"""
     )
   )
 
@@ -65,7 +65,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`POST /contacts/individual`,
     List(
       """case request @ POST -> Root / "contacts" / "individual" =>""",
-      """  errorHandler.resolve(request.as[IndividualContact].flatMap(impl.`POST /contacts/individual`(_)(request)), (x: IndividualContact) => EntityGenerator(200)(x.asJson))"""
+      """  errorHandler.resolve(request.as[IndividualContact].flatMap(impl.`POST /contacts/individual`(_)(request)), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))"""
     )
   )
 
@@ -73,7 +73,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`POST /contacts/individual/empty`,
     List(
       """case request @ POST -> Root / "contacts" / "individual" / "empty" =>""",
-      """  errorHandler.resolve(impl.`POST /contacts/individual/empty`(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson))"""
+      """  errorHandler.resolve(impl.`POST /contacts/individual/empty`(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))"""
     )
   )
 
@@ -81,7 +81,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`GET /contacts/individual/{contacts-id}`,
     List(
       """case request @ GET -> Root / "contacts" / "individual" / contactsId =>""",
-      "  errorHandler.resolve(impl.`GET /contacts/individual/{contacts-id}`(contactsId)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(impl.`GET /contacts/individual/{contacts-id}`(contactsId)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -89,7 +89,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`GET /org/{org-id}/contacts/individual/{contacts-id}`,
     List(
       """case request @ GET -> Root / "org" / orgId / "contacts" / "individual" / contactsId =>""",
-      "  errorHandler.resolve(impl.`GET /org/{org-id}/contacts/individual/{contacts-id}`(orgId, contactsId)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(impl.`GET /org/{org-id}/contacts/individual/{contacts-id}`(orgId, contactsId)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -97,7 +97,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`PUT /contacts/individual/{contacts-id}`,
     List(
       """case request @ PUT -> Root / "contacts" / "individual" / contactsId =>""",
-      "  errorHandler.resolve(request.as[IndividualContact].flatMap(impl.`PUT /contacts/individual/{contacts-id}`(contactsId, _)(request)), (x: IndividualContact) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(request.as[IndividualContact].flatMap(impl.`PUT /contacts/individual/{contacts-id}`(contactsId, _)(request)), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -105,7 +105,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`PUT /contacts/individual/empty/{contacts-id}`,
     List(
       """case request @ PUT -> Root / "contacts" / "individual" / "empty" / contactsId =>""",
-      "  errorHandler.resolve(impl.`PUT /contacts/individual/empty/{contacts-id}`(contactsId)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(impl.`PUT /contacts/individual/empty/{contacts-id}`(contactsId)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -113,7 +113,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`PATCH /contacts/individual/{contacts-id}`,
     List(
       """case request @ PATCH -> Root / "contacts" / "individual" / contactsId =>""",
-      "  errorHandler.resolve(request.as[IndividualContact].flatMap(impl.`PATCH /contacts/individual/{contacts-id}`(contactsId, _)(request)), (x: IndividualContact) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(request.as[IndividualContact].flatMap(impl.`PATCH /contacts/individual/{contacts-id}`(contactsId, _)(request)), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -121,7 +121,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`DELETE /contacts/individual/{contacts-id}`,
     List(
       """case request @ DELETE -> Root / "contacts" / "individual" / contactsId =>""",
-      "  errorHandler.resolve(impl.`DELETE /contacts/individual/{contacts-id}`(contactsId)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(impl.`DELETE /contacts/individual/{contacts-id}`(contactsId)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -129,7 +129,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`GET /contacts/organization/{contacts-id}/addresses`,
     List(
       """case request @ GET -> Root / "contacts" / "organization" / contactsId / "addresses" =>""",
-      "  errorHandler.resolve(impl.`GET /contacts/organization/{contacts-id}/addresses`(contactsId)(request), (x: Address) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(impl.`GET /contacts/organization/{contacts-id}/addresses`(contactsId)(request), (x: Address) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -137,7 +137,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`POST /contacts/organization/{contacts-id}/addresses`,
     List(
       """case request @ POST -> Root / "contacts" / "organization" / contactsId / "addresses" =>""",
-      "  errorHandler.resolve(request.as[Address].flatMap(impl.`POST /contacts/organization/{contacts-id}/addresses`(contactsId, _)(request)), (x: Address) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(request.as[Address].flatMap(impl.`POST /contacts/organization/{contacts-id}/addresses`(contactsId, _)(request)), (x: Address) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -145,7 +145,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`GET /contacts/organization/{contacts-id}/addresses/{address-id}`,
     List(
       """case request @ GET -> Root / "contacts" / "organization" / contactsId / "addresses" / addressId =>""",
-      "  errorHandler.resolve(impl.`GET /contacts/organization/{contacts-id}/addresses/{address-id}`(contactsId, addressId)(request), (x: Address) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(impl.`GET /contacts/organization/{contacts-id}/addresses/{address-id}`(contactsId, addressId)(request), (x: Address) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -153,7 +153,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`PUT /contacts/organization/{contacts-id}/addresses/{address-id}`,
     List(
       """case request @ PUT -> Root / "contacts" / "organization" / contactsId / "addresses" / addressId =>""",
-      "  errorHandler.resolve(request.as[Address].flatMap(impl.`PUT /contacts/organization/{contacts-id}/addresses/{address-id}`(contactsId, addressId, _)(request)), (x: Address) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(request.as[Address].flatMap(impl.`PUT /contacts/organization/{contacts-id}/addresses/{address-id}`(contactsId, addressId, _)(request)), (x: Address) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -161,7 +161,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`DELETE /contacts/organization/{contacts-id}/addresses/{address-id}`,
     List(
       """case request @ DELETE -> Root / "contacts" / "organization" / contactsId / "addresses" / addressId =>""",
-      "  errorHandler.resolve(impl.`DELETE /contacts/organization/{contacts-id}/addresses/{address-id}`(contactsId, addressId)(request), (x: Address) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(impl.`DELETE /contacts/organization/{contacts-id}/addresses/{address-id}`(contactsId, addressId)(request), (x: Address) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -169,7 +169,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`GET /contacts/individual?query1&query2&optional1&optional2&list1&optional-list1`,
     List(
       """case request @ GET -> Root / "contacts" / "individual" :? `query1 QueryParamDecoderMatcher[String] Matcher`(query1) +& `query2 QueryParamDecoderMatcher[Int] Matcher`(query2) +& `optional1 OptionalQueryParamDecoderMatcher[String] Matcher`(optional1) +& `optional2 OptionalQueryParamDecoderMatcher[Int] Matcher`(optional2) +& `list1 QueryParamDecoderMatcher[List[Int]] Matcher`(list1) +& `optional-list1 OptionalQueryParamDecoderMatcher[List[String]] Matcher`(optionalList1) =>""",
-      "  errorHandler.resolve(impl.`GET /contacts/individual`(list1, optionalList1, optional1, optional2, query1, query2)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(impl.`GET /contacts/individual`(list1, optionalList1, optional1, optional2, query1, query2)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -177,7 +177,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`POST /contacts/individual?query1&query2&optional1&optional2&list1&optional-list1`,
     List(
       """case request @ POST -> Root / "contacts" / "individual" :? `query1 QueryParamDecoderMatcher[String] Matcher`(query1) +& `query2 QueryParamDecoderMatcher[Int] Matcher`(query2) +& `optional1 OptionalQueryParamDecoderMatcher[String] Matcher`(optional1) +& `optional2 OptionalQueryParamDecoderMatcher[Int] Matcher`(optional2) +& `list1 QueryParamDecoderMatcher[List[Int]] Matcher`(list1) +& `optional-list1 OptionalQueryParamDecoderMatcher[List[String]] Matcher`(optionalList1) =>""",
-      "  errorHandler.resolve(request.as[IndividualContact].flatMap(impl.`POST /contacts/individual`(list1, optionalList1, optional1, optional2, query1, query2, _)(request)), (x: IndividualContact) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(request.as[IndividualContact].flatMap(impl.`POST /contacts/individual`(list1, optionalList1, optional1, optional2, query1, query2, _)(request)), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -185,7 +185,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`GET /contacts/individual/{contacts-id}?optional1&optional2`,
     List(
       """case request @ GET -> Root / "contacts" / "individual" / contactsId :? `optional1 OptionalQueryParamDecoderMatcher[String] Matcher`(optional1) +& `optional2 OptionalQueryParamDecoderMatcher[Int] Matcher`(optional2) =>""",
-      "  errorHandler.resolve(impl.`GET /contacts/individual/{contacts-id}`(contactsId, optional1, optional2)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(impl.`GET /contacts/individual/{contacts-id}`(contactsId, optional1, optional2)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -193,7 +193,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`PUT /contacts/individual/{contacts-id}?optional1&optional2`,
     List(
       """case request @ PUT -> Root / "contacts" / "individual" / contactsId :? `optional1 OptionalQueryParamDecoderMatcher[String] Matcher`(optional1) +& `optional2 OptionalQueryParamDecoderMatcher[Int] Matcher`(optional2) =>""",
-      "  errorHandler.resolve(request.as[IndividualContact].flatMap(impl.`PUT /contacts/individual/{contacts-id}`(contactsId, optional1, optional2, _)(request)), (x: IndividualContact) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(request.as[IndividualContact].flatMap(impl.`PUT /contacts/individual/{contacts-id}`(contactsId, optional1, optional2, _)(request)), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -201,7 +201,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`DELETE /contacts/individual/{contacts-id}?optional1&optional2`,
     List(
       """case request @ DELETE -> Root / "contacts" / "individual" / contactsId =>""",
-      "  errorHandler.resolve(impl.`DELETE /contacts/individual/{contacts-id}`(contactsId)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(impl.`DELETE /contacts/individual/{contacts-id}`(contactsId)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -209,7 +209,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`GET /contacts/organization/{contacts-id}/addresses?query1&query2`,
     List(
       """case request @ GET -> Root / "contacts" / "organization" / contactsId / "addresses" :? `query1 QueryParamDecoderMatcher[String] Matcher`(query1) +& `query2 QueryParamDecoderMatcher[Int] Matcher`(query2) =>""",
-      "  errorHandler.resolve(impl.`GET /contacts/organization/{contacts-id}/addresses`(contactsId, query1, query2)(request), (x: Address) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(impl.`GET /contacts/organization/{contacts-id}/addresses`(contactsId, query1, query2)(request), (x: Address) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -217,7 +217,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`POST /contacts/organization/{contacts-id}/addresses?query1&query2`,
     List(
       """case request @ POST -> Root / "contacts" / "organization" / contactsId / "addresses" :? `query1 QueryParamDecoderMatcher[String] Matcher`(query1) +& `query2 QueryParamDecoderMatcher[Int] Matcher`(query2) =>""",
-      "  errorHandler.resolve(request.as[Address].flatMap(impl.`POST /contacts/organization/{contacts-id}/addresses`(contactsId, query1, query2, _)(request)), (x: Address) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(request.as[Address].flatMap(impl.`POST /contacts/organization/{contacts-id}/addresses`(contactsId, query1, query2, _)(request)), (x: Address) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -225,7 +225,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`GET /contacts/organization/{contacts-id}/addresses/{address-id}?list1&list2`,
     List(
       """case request @ GET -> Root / "contacts" / "organization" / contactsId / "addresses" / addressId :? `list1 QueryParamDecoderMatcher[List[String]] Matcher`(list1) +& `list2 QueryParamDecoderMatcher[List[Int]] Matcher`(list2) =>""",
-      "  errorHandler.resolve(impl.`GET /contacts/organization/{contacts-id}/addresses/{address-id}`(contactsId, addressId, list1, list2)(request), (x: Address) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(impl.`GET /contacts/organization/{contacts-id}/addresses/{address-id}`(contactsId, addressId, list1, list2)(request), (x: Address) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -233,7 +233,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`PUT /contacts/organization/{contacts-id}/addresses/{address-id}?list1&list2`,
     List(
       """case request @ PUT -> Root / "contacts" / "organization" / contactsId / "addresses" / addressId :? `list1 QueryParamDecoderMatcher[List[String]] Matcher`(list1) +& `list2 QueryParamDecoderMatcher[List[Int]] Matcher`(list2) =>""",
-      "  errorHandler.resolve(request.as[Address].flatMap(impl.`PUT /contacts/organization/{contacts-id}/addresses/{address-id}`(contactsId, addressId, list1, list2, _)(request)), (x: Address) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(request.as[Address].flatMap(impl.`PUT /contacts/organization/{contacts-id}/addresses/{address-id}`(contactsId, addressId, list1, list2, _)(request)), (x: Address) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -241,7 +241,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`DELETE /contacts/organization/{contacts-id}/addresses/{address-id}?list1&list2`,
     List(
       """case request @ DELETE -> Root / "contacts" / "organization" / contactsId / "addresses" / addressId =>""",
-      "  errorHandler.resolve(impl.`DELETE /contacts/organization/{contacts-id}/addresses/{address-id}`(contactsId, addressId)(request), (x: Address) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(impl.`DELETE /contacts/organization/{contacts-id}/addresses/{address-id}`(contactsId, addressId)(request), (x: Address) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -249,7 +249,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`GET /contacts/individual?optional-list1&optional-list2`,
     List(
       """case request @ GET -> Root / "contacts" / "individual" :? `optional-list1 OptionalQueryParamDecoderMatcher[List[String]] Matcher`(optionalList1) +& `optional-list2 OptionalQueryParamDecoderMatcher[List[Int]] Matcher`(optionalList2) =>""",
-      "  errorHandler.resolve(impl.`GET /contacts/individual`(optionalList1, optionalList2)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(impl.`GET /contacts/individual`(optionalList1, optionalList2)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -257,7 +257,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`POST /contacts/individual?optionaoListl1&optional-list2`,
     List(
       """case request @ POST -> Root / "contacts" / "individual" :? `optional-list1 OptionalQueryParamDecoderMatcher[List[String]] Matcher`(optionalList1) +& `optional-list2 OptionalQueryParamDecoderMatcher[List[Int]] Matcher`(optionalList2) =>""",
-      "  errorHandler.resolve(request.as[IndividualContact].flatMap(impl.`POST /contacts/individual`(optionalList1, optionalList2, _)(request)), (x: IndividualContact) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(request.as[IndividualContact].flatMap(impl.`POST /contacts/individual`(optionalList1, optionalList2, _)(request)), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -265,7 +265,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`GET /contacts/individual/funny.,argument/type/?other:@funny&trait`,
     List(
       """case request @ GET -> Root / "contacts" / "individual" / funny_Argument / typeParameter :? `other:@funny QueryParamDecoderMatcher[String] Matcher`(other_Funny) +& `trait QueryParamDecoderMatcher[String] Matcher`(traitParameter) =>""",
-      "  errorHandler.resolve(impl.`GET /contacts/individual/{funny.,argument}/{type}`(funny_Argument, typeParameter, other_Funny, traitParameter)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson))"
+      "  errorHandler.resolve(impl.`GET /contacts/individual/{funny.,argument}/{type}`(funny_Argument, typeParameter, other_Funny, traitParameter)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))"
     )
   )
 
@@ -273,7 +273,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`POST /contacts/single`,
     List(
       """case request @ POST -> Root / "contacts" / "single" =>""",
-      """  errorHandler.resolve(request.as[String].flatMap(impl.`POST /contacts/single`(_)(request)), (x: IndividualContact) => EntityGenerator(200)(x.asJson))"""
+      """  errorHandler.resolve(request.as[String].flatMap(impl.`POST /contacts/single`(_)(request)), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))"""
     )
   )
 
@@ -281,7 +281,7 @@ class RouteGeneratorSpec extends AnyFreeSpec with Matchers {
     RouteDefinitions.`GET /contacts/individual?queryEnum`,
     List(
       """case request @ GET -> Root / "contacts" / "individual" :? `queryEnum QueryParamDecoderMatcher[#/components/schemas/IndividualContact.IndividualContact] Matcher`(queryEnum) =>""",
-      """  errorHandler.resolve(impl.`GET /contacts/individual`(queryEnum)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson))"""
+      """  errorHandler.resolve(impl.`GET /contacts/individual`(queryEnum)(request), (x: IndividualContact) => EntityGenerator(200)(x.asJson.dropNullValues))"""
     )
   )
 


### PR DESCRIPTION
We automatically derive Circe encoders and decoders for the case classes in our generator. While for any input to the API server, Circe will allow undefined as well as `null` value fields in JSON in place of optional/default values.

This is okay since both cases are valid inputs to our APIs. However, we have noticed that the end-user of the API sometimes matches on `null` or `undefined`. While we can ask our users to match on both, it's convenient to always have a single case.

This PR ensures that the optional fields with no values are not included in the output JSON. This has the added advantage of reducing the data on the wire.